### PR TITLE
Attempts to migrate to Sonatype's new publishing mechanism: attempt 2

### DIFF
--- a/.github/workflows/mvn-release-prepare-perform.yaml
+++ b/.github/workflows/mvn-release-prepare-perform.yaml
@@ -58,6 +58,8 @@ jobs:
       - id: 'mvn-release-prepare'
         name: 'Step: Maven Release: Prepare, Perform and Publish Site'
         env:
+          CENTRAL_SONATYPE_COM_PASSWORD: '${{ secrets.CENTRAL_SONATYPE_COM_PASSWORD }}'
+          CENTRAL_SONATYPE_COM_USERNAME: '${{ secrets.CENTRAL_SONATYPE_COM_USERNAME }}'
           DRY_RUN: '${{ inputs.dryRun }}'
           GIT_ASKPASS: '${{ runner.temp }}/.askpass'
           GPG_PASSPHRASE: '${{ secrets.GPG_PASSPHRASE }}'

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ as a Maven dependency:
     Always check https://search.maven.org/artifact/org.microbean/microbean-construct
     for up-to-date available versions.
   -->
-  <version>0.0.13</version>
+  <version>0.0.14</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Added missing environment variables in `mvn-release-prepare-perform.yaml`.